### PR TITLE
Configure webpack watch task

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   },
   "scripts": {
     "test": "jest",
-    "build": "webpack --config webpack.config.js"
+    "build": "webpack --config webpack.config.js",
+    "watch": "webpack --config webpackWatch.config.js"
   },
   "repository": {
     "type": "git",

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,12 @@ $ ./gradlew run
 ```
 See http://yourIP:8080 for a web interface (see the console for the right IP:port). You can also try `gradle marcos`, `gradle bob`, and go to `/examples` for more sample projects and information about how to run them.
 
+
+### Making front end changes
+If you want to make changes to the jacamo-web front end, install [Node.js](https://nodejs.org/) and install the webpack client with ``npm install -g webpack client``.
+Then, install the jacamo-web front end dependencies by running ``npm install`` in the project's root repository.
+Run the webpack watch task with ``npm run watch``. All changes you make to JavaScript files will be automatically built and deployed to your local jacamo-web instance.
+
 ### Using a local docker
 
 ```sh

--- a/webpackWatch.config.js
+++ b/webpackWatch.config.js
@@ -1,0 +1,10 @@
+const config = require('./webpack.config');
+
+module.exports = {
+    ...config,
+    watch: true,
+    watchOptions: {
+    aggregateTimeout: 300,
+        poll: 1000
+    }
+};


### PR DESCRIPTION
And document how to use it; now, we can start the watch task with ``npm run watch`` and make changes to the front end that are auto-deployed to the local instance, without the need to manually run the build script.