### PR TITLE
Speedup webpack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,10 @@ out
 .DS_Store
 
 /node_modules/
+
+src/resources/js/d3-graphviz.js
+src/resources/js/d3.js
+src/resources/js/jacamoweb.js
+src/resources/js/vendors~d3-graphviz.js
+src/resources/js/vendors~d3.js
+src/resources/js/vendors~d3~d3-graphviz.js

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "regenerator-runtime": "^0.13.3",
     "terser-webpack-plugin": "^1.2.2",
     "webpack": "^4.43.0",
-    "webpack-dev-server": "^3.1.11",
-    "webpack-cli": "^3.3.10"
+    "webpack-cli": "^3.3.10",
+    "webpack-dev-server": "^3.11.0"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,7 @@ module.exports = {
   module: {
     rules: [{
       test: /\.js$/,
-      exclude: /(node_modules)/,
+      include: path.resolve(__dirname, 'src/js'),
       use: {
         loader: 'babel-loader',
         options: {

--- a/webpackWatch.config.js
+++ b/webpackWatch.config.js
@@ -1,10 +1,16 @@
+const path = require('path');
 const config = require('./webpack.config');
 
 module.exports = {
     ...config,
     watch: true,
     watchOptions: {
-    aggregateTimeout: 300,
-        poll: 1000
-    }
+        aggregateTimeout: 300,
+        poll: 1000,
+        ignored: [/node_modules/]
+    },
+    resolve: {
+        unsafeCache: true,
+    },
+    mode: 'development'
 };


### PR DESCRIPTION
As discussed. When running the watch task ``npm run watch`` and making changes to a JS file (after the watch task has everything set up and is "watching"), the changes should be deployed quite quickly.