### PR TITLE
Fix setupYarn task when using docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,14 @@ FROM openjdk:8-jdk-alpine
 #ENV JACAMO_HOME=/jacamo/build
 ENV PATH $PATH:$JAVA_HOME/bin #:$JACAMO_HOME/scripts
 
-RUN apk add --update --no-cache git bash fontconfig ttf-dejavu graphviz
+RUN apk add --update --no-cache git bash fontconfig ttf-dejavu graphviz nodejs npm
 
 # download and run jacamo-web (just to update local maven rep)
 RUN git clone https://github.com/jacamo-lang/jacamo-web.git && \
     cd jacamo-web && \
-    ./gradlew build
+    ./gradlew run # To deploy on heroku, use build instead
+#    ./gradlew build # To lauch jacamo-web automatically, use run instead
+
 
 EXPOSE 3271
 EXPOSE 3272

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
   id "eclipse"
   id "maven-publish"
   id "com.github.johnrengelman.shadow" version "5.2.0"
-  id "com.moowork.node" version "1.3.1"
+  id "com.github.node-gradle.node" version "2.2.0"
 }
 
 defaultTasks 'run'
@@ -25,7 +25,7 @@ java {
 
 repositories {
 	mavenCentral()
-	maven { url "https://raw.github.com/jacamo-lang/mvn-repo/master" }
+	maven { url "https://raw.githubusercontent.com/jacamo-lang/mvn-repo/master" }
 	flatDir {
 		dirs 'lib'
 	}
@@ -205,9 +205,9 @@ node {
        ./gradlew npm_<command> Executes an NPM command.
     */
     // Version of node to use.
-    version = '10.14.1'
+    version = '14.17.5'
     // Version of yarn to use.
-    yarnVersion = '1.15.2'
+    yarnVersion = '1.22.5'
     // If true, it will download node using above parameters.
     // If false, it will try to use globally installed node.
     download = true

--- a/readme.md
+++ b/readme.md
@@ -31,13 +31,10 @@ Run the webpack watch task with ``yarn run watch``. All changes you make to Java
 ### Using a local docker
 
 ```sh
-$ docker build  -t jacamo-runrest .
-$ docker network create jcm_net
-$ docker run -ti --rm --net jcm_net  --name host1 -v "$(pwd)":/app jacamo-runrest gradle marcos
-$ docker run -ti --rm --net jcm_net  --name host2 -v "$(pwd)":/app jacamo-runrest gradle bob_d
+$ docker build  -t jomifred/jacamo-web .
 ```
 
-These commands build a docker image and launch marcos and bob projects. Usually super user privileges are necessary.
+Usually super user privileges are necessary. It will take some minutes to run everything since it will create a docker image and run a container with a basic jacamo-web application running. At the very end of the log, you should see a message similar to "jacamo-web Rest API is running on http://172.17.0.2:8080/", so you can open your browser on the referred URL.
 
 ### Deploying from local repository to Heroku
 


### PR DESCRIPTION
Dockerfile was missing the installation of nodejs and npm. Besides,` com.moowork.node` seems to have some issues with new gradle versions. Luckly, the fork `com.github.node-gradle.node` is fixing it. New versions of node and yarn were also set. Fix #71.